### PR TITLE
Convert tests to new way of using robot configuration

### DIFF
--- a/src/test/java/libraries/cyberlib/control/HolonomicTrajectoryFollowerTest.java
+++ b/src/test/java/libraries/cyberlib/control/HolonomicTrajectoryFollowerTest.java
@@ -43,7 +43,8 @@ class HolonomicTrajectoryFollowerTest {
         System.out.println(String.format("trajectoryTime: %f", trajectoryTime));
         System.out.println(trajectory.toString());
 
-        var mServeConfiguration = Robot2022.kSwerveConfiguration;
+        var mRobotConfiguration = new Robot2022();
+        var mServeConfiguration = mRobotConfiguration.getSwerveConfiguration();
 
         var follower = new HolonomicTrajectoryFollower(
                 new PidGains(0.4, 0.0, 0.025),

--- a/src/test/java/libraries/cyberlib/control/PurePursuitTrajectoryFollowerTest.java
+++ b/src/test/java/libraries/cyberlib/control/PurePursuitTrajectoryFollowerTest.java
@@ -44,7 +44,8 @@ class PurePursuitTrajectoryFollowerTest {
         System.out.println(String.format("trajectoryTime: %f", trajectoryTime));
         System.out.println(trajectory.toString());
 
-        var mServeConfiguration = Robot2022.kSwerveConfiguration;
+        var mRobotConfiguration = new Robot2022();
+        var mServeConfiguration = mRobotConfiguration.getSwerveConfiguration();
 
         var follower = new PurePursuitTrajectoryFollower(mServeConfiguration);
         follower.follow(new TrajectoryIterator<TimedState<Pose2dWithCurvature>>(trajectory.getIndexView()));


### PR DESCRIPTION
These tests were using the old static way of referencing robot configs. This change just updates to the newer way of creating a Robot2022() object to ensure the tests compile.