### PR TITLE
Fix config depdendency

### DIFF
--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -46,8 +46,10 @@ public class Swerve extends Subsystem {
 
 	// Module declaration
 	private final List<SwerveDriveModule> mModules = new ArrayList<>();
-	public SwerveDriveModule mFrontRight=null;
-	private SwerveDriveModule mFrontLeft=null, mBackLeft=null, mBackRight=null;
+	private final SwerveDriveModule mFrontRight;
+    private final SwerveDriveModule mFrontLeft;
+    private final SwerveDriveModule mBackLeft;
+    private final SwerveDriveModule mBackRight;
 
 	double lastUpdateTimestamp = 0;
 
@@ -86,10 +88,6 @@ public class Swerve extends Subsystem {
     private Swerve(String caller) {
         sClassName = this.getClass().getSimpleName();
         printUsage(caller);
-        int m0 = 0;
-        int m1 = 0;
-        int m2 = 0;
-        int m3 = 0;
 
         mRobotConfiguration = RobotConfiguration.getRobotConfiguration(RobotName.name);
 
@@ -104,9 +102,7 @@ public class Swerve extends Subsystem {
 		mOdometry = new SwerveDriveOdometry(mKinematics, mIMU.getYaw());
         mPeriodicIO.robotPose = mOdometry.getPose();
 
-        // mMotionPlanner = new DriveMotionPlanner();
-
-//        generator = TrajectoryGenerator.getInstance();
+         mMotionPlanner = new DriveMotionPlanner();
     }
 
     private final Loop loop = new Loop() {
@@ -288,11 +284,10 @@ public class Swerve extends Subsystem {
 
     /**
      * Updates the field relative position of the robot.
-     *
+     * <p>
      * @param timestamp The current time
      */
     private void updateOdometry(double timestamp) {
-
         var frontRight = mFrontRight.getState();
         var frontLeft = mFrontLeft.getState();
         var backLeft = mBackLeft.getState();
@@ -302,7 +297,6 @@ public class Swerve extends Subsystem {
         mPeriodicIO.chassisSpeeds = mKinematics.toChassisSpeeds(frontRight, frontLeft, backLeft, backRight);
         mPeriodicIO.robotPose = mOdometry.updateWithTime(timestamp, getAngle(), frontRight, frontLeft, backLeft, backRight);
     }
-
 
     /**
      * Gets whether path following is done or not.  Typically, called in autonomous actions.
@@ -359,6 +353,8 @@ public class Swerve extends Subsystem {
 
     /**
      * Configure modules for open loop control
+     * <p>
+     * @param signal The HolonomicDriveSignal to apply
      */
     public synchronized void setOpenLoop(HolonomicDriveSignal signal) {
         if (mControlState != ControlState.MANUAL) {
@@ -370,6 +366,8 @@ public class Swerve extends Subsystem {
 
     /**
      * Configure modules for path following.
+     * <p>
+     * @param signal The HolonomicDriveSignal to apply
      */
     public synchronized void setPathFollowingVelocity(HolonomicDriveSignal signal) {
         if (mControlState != ControlState.PATH_FOLLOWING) {
@@ -407,7 +405,7 @@ public class Swerve extends Subsystem {
 
     /**
      * Sets inputs from driver in teleop mode.
-     *
+     * <p>
      * @param forward percent to drive forwards/backwards (as double [-1.0,1.0]).
      * @param strafe percent to drive sideways left/right (as double [-1.0,1.0]).
      * @param rotation percent to rotate chassis (as double [-1.0,1.0]).
@@ -546,7 +544,7 @@ public class Swerve extends Subsystem {
 
         // Updated as part of trajectory following
         public Pose2d error = Pose2d.identity();
-        public TimedState<Pose2dWithCurvature> path_setpoint = new TimedState<Pose2dWithCurvature>(Pose2dWithCurvature.identity());
+        public TimedState<Pose2dWithCurvature> path_setpoint = new TimedState<>(Pose2dWithCurvature.identity());
 
 
         // Inputs

--- a/src/main/java/libraries/cyberlib/control/PurePursuitTrajectoryFollower.java
+++ b/src/main/java/libraries/cyberlib/control/PurePursuitTrajectoryFollower.java
@@ -1,7 +1,6 @@
 package libraries.cyberlib.control;
 
 import frc.robot.Constants;
-import frc.robot.subsystems.SwerveConfiguration;
 import libraries.cheesylib.geometry.Pose2d;
 import libraries.cheesylib.geometry.Pose2dWithCurvature;
 import libraries.cheesylib.geometry.Translation2d;
@@ -17,10 +16,8 @@ public class PurePursuitTrajectoryFollower extends TrajectoryFollower<HolonomicD
     private boolean mIsReversed = false;
     private boolean mIsReversedCalulated = false;
     private boolean mFinished = false;
-    private final SwerveConfiguration mSwerveConfiguration;
 
-    public PurePursuitTrajectoryFollower(SwerveConfiguration swerveConfiguration) {
-        this.mSwerveConfiguration = swerveConfiguration;
+    public PurePursuitTrajectoryFollower() {
     }
 
     @Override
@@ -51,7 +48,7 @@ public class PurePursuitTrajectoryFollower extends TrajectoryFollower<HolonomicD
                     , lookahead_state.velocity(), lookahead_state.acceleration());
         }
 
-        var normalizedVelocity = lookahead_state.velocity() / mSwerveConfiguration.maxSpeedInMetersPerSecond;
+        var normalizedVelocity = lookahead_state.velocity();
 
         // Now calculate velocities
         Translation2d segmentVelocity = new Translation2d(
@@ -72,11 +69,8 @@ public class PurePursuitTrajectoryFollower extends TrajectoryFollower<HolonomicD
         // w = (theta(1) - theta(0)) / dt
         double rotationVelocity = Angles.normalizeAngle(theta1 - theta0) / dt;
 
-        // Scale it to a percentage of max angular velocity as Swerve will scale it correctly
-        rotationVelocity /= mSwerveConfiguration.maxSpeedInRadiansPerSecond;
-
         var signal = new HolonomicDriveSignal(segmentVelocity, rotationVelocity, true);
-        System.out.println(signal); // brian leave until fixed
+
         return signal;
     }
 

--- a/src/test/java/libraries/cyberlib/control/HolonomicTrajectoryFollowerTest.java
+++ b/src/test/java/libraries/cyberlib/control/HolonomicTrajectoryFollowerTest.java
@@ -43,7 +43,8 @@ class HolonomicTrajectoryFollowerTest {
         System.out.println(String.format("trajectoryTime: %f", trajectoryTime));
         System.out.println(trajectory.toString());
 
-        var mServeConfiguration = Robot2022.kSwerveConfiguration;
+        var mRobotConfiguration = new Robot2022();
+        var mServeConfiguration = mRobotConfiguration.getSwerveConfiguration();
 
         var follower = new HolonomicTrajectoryFollower(
                 new PidGains(0.4, 0.0, 0.025),
@@ -99,7 +100,6 @@ class HolonomicTrajectoryFollowerTest {
             // Now update odometry (assume swerve modules execute perfectly )
             position = m_odometry.updateWithTime(currentTime, gyro, swerveModuleStates);
             System.out.printf("time: %.2f - %s%n", currentTime, position.toString());
-
-        }
+       }
     }
 }

--- a/src/test/java/libraries/cyberlib/control/PurePursuitTrajectoryFollowerTest.java
+++ b/src/test/java/libraries/cyberlib/control/PurePursuitTrajectoryFollowerTest.java
@@ -44,9 +44,10 @@ class PurePursuitTrajectoryFollowerTest {
         System.out.println(String.format("trajectoryTime: %f", trajectoryTime));
         System.out.println(trajectory.toString());
 
-        var mServeConfiguration = Robot2022.kSwerveConfiguration;
+        var mRobotConfiguration = new Robot2022();
+        var mServeConfiguration = mRobotConfiguration.getSwerveConfiguration();
 
-        var follower = new PurePursuitTrajectoryFollower(mServeConfiguration);
+        var follower = new PurePursuitTrajectoryFollower();
         follower.follow(new TrajectoryIterator<TimedState<Pose2dWithCurvature>>(trajectory.getIndexView()));
 
         var chassisSpeeds = new ChassisSpeeds();


### PR DESCRIPTION
Fixed config dependencies.
Enable DriveMotionPlanner in Swerve.
Default to HolonomicTrajectoryFollower
Properly scale velocities from path followers in DriveMotionPlanner before returning the HolonomicDriveSignal.
Fix issue where TrajectoryFollower would not return HolonomicDriveSignal correctly,