### PR TITLE
Fix driver flow for resetting the field-oriented drive

### DIFF
--- a/src/main/java/frc/robot/subsystems/JSticks.java
+++ b/src/main/java/frc/robot/subsystems/JSticks.java
@@ -181,7 +181,7 @@ public class JSticks extends Subsystem {
         if (mPeriodicIO.dr_YButton_ResetIMU) {
             // Seems safest to disable heading controller if were resetting IMU.
             mHeadingController.setHeadingControllerState(SwerveHeadingController.HeadingControllerState.OFF);
-            mSwerve.zeroSensors(Constants.kRobotStartingPose);
+            mSwerve.setRobotPosition(Constants.kRobotStartingPose);
         }
 
         if (mPeriodicIO.dr_StartButton_ResetWheels){

--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -450,6 +450,9 @@ public class Swerve extends Subsystem {
     /**
      * Zeroes the drive motors, and sets the robot's internal position and heading
      * to match that of the fed pose
+     *
+     * DO NOT use this to reset the IMU mid match. Use
+     * {@link #setRobotPosition(Pose2d)} for that purpose.
      */
     public synchronized void zeroSensors(Pose2d startingPose) {
         setRobotPosition(startingPose);


### PR DESCRIPTION
Previously we have called `Swerve.zeroSensors()` which both sets the robot position and updates the IMU. This
has caused issues which incidentally was fixed by calling zeroSensors twice, but that's not the fix we _should_ be doing.

This updates the code to instead just call `setRobotPosition`, which handles things as expected, and adds a comment to avoid this from happening again in the future.