### PR TITLE
driver joystick should rumble for 2 seconds  when robot enabled

### DIFF
--- a/src/main/java/frc/robot/subsystems/JSticks.java
+++ b/src/main/java/frc/robot/subsystems/JSticks.java
@@ -140,6 +140,9 @@ public class JSticks extends Subsystem {
     }
 
     private SystemState handleReadingButtons() {
+        if (mStateChanged){
+            mDriver.rumble(5, 2);
+        }
         teleopRoutines();
 
         return defaultStateTransfer();


### PR DESCRIPTION
this is for the joysticks swapping randomly

This is untested. The WPI joystick class has a rumble method that I supported in CW. I have never had an opportunity to use it until now. This means that it may not work for a number of reasons beyond the simple change this PR has in it. I think it is very safe if it works. And this PR is into main. You may be able to PR into our GP branch if you prefer or just copy and paste if that is easier.