### PR TITLE
Slew rate limiter on translation for better driver control

### DIFF
--- a/src/main/java/frc/robot/subsystems/JSticks.java
+++ b/src/main/java/frc/robot/subsystems/JSticks.java
@@ -168,6 +168,10 @@ public class JSticks extends Subsystem {
         Superstructure.WantedState currentState = mSuperstructure.getWantedState();
         Superstructure.WantedState previousState = currentState;
 
+        // if(mPeriodicIO.dr_AButton_ToggleDriveMode) {
+        //     mSwerve.toggleThroughDriveModes();
+        // }
+
         // NEW SWERVE
         if (mSuperstructure.getWantedState() != Superstructure.WantedState.AUTO_SHOOT) {
         // All driver assist to raw inputs should be implemented Swerve#handleManual()
@@ -176,8 +180,8 @@ public class JSticks extends Subsystem {
             double swerveRotationInput = mPeriodicIO.dr_RightStickX_Rotate;
 
             if (mPeriodicIO.dr_LeftTrigger_SlowSpeed) {
-                swerveYInput *= 0.5;
-                swerveXInput *= 0.5;
+                swerveYInput *= 0.25;
+                swerveXInput *= 0.25;
                 swerveRotationInput *= 0.5;
             }
 
@@ -361,7 +365,7 @@ public class JSticks extends Subsystem {
         mPeriodicIO.dr_RightTrigger_AutoShoot_Stop = mDriver.getButton(Xbox.RIGHT_TRIGGER, CW.RELEASED_EDGE);
         mPeriodicIO.dr_RightBumper_RobotOrient = mDriver.getButton(Xbox.RIGHT_BUMPER, CW.PRESSED_LEVEL); // field/robot
         mPeriodicIO.dr_YButton_ResetIMU = mDriver.getButton(Xbox.Y_BUTTON, CW.PRESSED_EDGE);
-        // mPeriodicIO.dr_AButton_ToggleDriveMode = mDriver.getButton(Xbox.A_BUTTON, CW.PRESSED_EDGE);
+        mPeriodicIO.dr_AButton_ToggleDriveMode = mDriver.getButton(Xbox.A_BUTTON, CW.PRESSED_EDGE);
         mPeriodicIO.dr_StartButton_ResetWheels = mDriver.getButton(Xbox.START_BUTTON, CW.PRESSED_EDGE);
 
         //Climbing

--- a/src/main/java/frc/robot/subsystems/Superstructure.java
+++ b/src/main/java/frc/robot/subsystems/Superstructure.java
@@ -293,7 +293,7 @@ public class Superstructure extends Subsystem {
             mShooter.setWantedState(Shooter.WantedState.SHOOT, sClassName);
             mSetPointInRadians = Double.NaN;
         }
-         var setPointInRadians = getSwerveSetpointFromVision(timestamp);
+        var setPointInRadians = getSwerveSetpointFromVision(timestamp);
         
         // SmartDashboard.putNumber("setPointHeading degrees", Math.toDegrees(setPointInRadians));
 //        System.out.println("SetPointInRadians: " + setPointInRadians + " Degrees: " + Math.toDegrees(setPointInRadians));
@@ -556,7 +556,7 @@ public class Superstructure extends Subsystem {
             mYOffset = mLLManager.getLimelight().getYOffset();
 
             mHasTarget = true;
-            mOnTarget = Util.epsilonEquals(llTX, 0.0, 1.5);
+            mOnTarget = Util.epsilonEquals(llTX, 0.0, 3);
 
             // System.out.println("SS getSwerveSetpoint tx:"+llTX+" heading:"+Math.toDegrees(mSwerve.getHeading().getRadians()));
             return Angles.normalizeAngle(setPointInRadians);        }

--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.ctre.phoenix.motorcontrol.NeutralMode;
 
+import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer;
@@ -56,7 +57,7 @@ public class Swerve extends Subsystem {
 
     double lastUpdateTimestamp = 0;
     double rotationPow = 2;
-    int driveMode = 2;
+    int driveMode = 3;
 
     // Swerve kinematics & odometry
     private final IMU mIMU;
@@ -217,6 +218,10 @@ public class Swerve extends Subsystem {
         }
     }
 
+    SlewRateLimiter forwardLimiter = new SlewRateLimiter(1.5, 0);
+    SlewRateLimiter strafeLimiter = new SlewRateLimiter(1.5, 0);
+    SlewRateLimiter rotationLimiter = new SlewRateLimiter(2, 0);
+
     /**
      * Handles MANUAL state which corresponds to joy stick inputs.
      *
@@ -258,11 +263,14 @@ public class Swerve extends Subsystem {
                         mPeriodicIO.field_relative);
                 break;
             case 3:
-                // Raw inputs
+                // Slew Rate Limiter
                 driveSignal = new HolonomicDriveSignal(
-                         new Translation2d(mPeriodicIO.forward,mPeriodicIO.strafe),
-                         mPeriodicIO.rotation,
-                         mPeriodicIO.field_relative);
+                        new Translation2d(
+                        forwardLimiter.calculate(mPeriodicIO.forward),
+                        strafeLimiter.calculate(mPeriodicIO.strafe)),
+                        // rotationLimiter.calculate(mPeriodicIO.rotation),
+                        Math.copySign(Math.pow(mPeriodicIO.rotation, 2), mPeriodicIO.rotation),
+                        mPeriodicIO.field_relative);
                 break;
             default:
                 driveSignal = null;
@@ -496,7 +504,7 @@ public class Swerve extends Subsystem {
      */
     public synchronized void setOpenLoop(HolonomicDriveSignal signal) {
         if (mControlState != ControlState.MANUAL) {
-            setBrakeMode(true); // TODO: Consider driving in coast mode
+            setBrakeMode(true);
             mControlState = ControlState.MANUAL;
         }
         updateModules(signal);


### PR DESCRIPTION
Includes the addition of a SlewRateLimiter drive mode to set acceleration of swerve translation. Rotation inputs remain squared. Slew rate limits on the rotation caused unusual behavior, potentially due to overlapping control from the heading controller pid or other unknown reasons. The new drive mode has been made default after testing with drive team.